### PR TITLE
Add matching id to code/button parent

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,7 +32,7 @@ function renderCode(origRule, rendererOptions) {
       return origRendered;
     }
     return `
-<div style="position: relative">
+<div style="position: relative" id="code-container-${idx}">
   ${origRendered.replace(/<code/, `<code id="code-${idx}"`)}
   <button class="${rendererOptions.buttonClass} ${rendererOptions.additionalButtonClass}"
     data-clipboard-target="#code-${idx}"


### PR DESCRIPTION
Adds an attribute on the parent `<div>` container for the code block to bette track interactivity with the code fence